### PR TITLE
1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Put your changes here...
 
+## 1.0.2
+
+- Fixed a crash caused by not populating the `exemptNames` param.
+
 ## 1.0.1
 
 - Added option to exempt specific values from being renamed.

--- a/minify-html-attributes.js
+++ b/minify-html-attributes.js
@@ -94,7 +94,7 @@ function minifyHtmlAttributes (params) {
         if (attrsToRename.includes(attr) || (attr.startsWith('data-') && !params?.disableDataReplacements)) {
           const values = attributes[attr].split(' ')
           const newValues = values.map(value => {
-            if (params?.exemptNames.includes(value)) return value
+            if (params?.exemptNames?.includes(value)) return value
             if (!nameMap[value]) {
               const minified = minifiedNameGenerator.next().value
               nameMap[value] = minified

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minify-html-attributes",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minify-html-attributes",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "CC-BY-4.0",
       "dependencies": {
         "acorn": "8.14.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/minify-html-attributes/graphs/contributors"
     }
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/rooseveltframework/minify-html-attributes",
   "license": "CC-BY-4.0",
   "main": "minify-html-attributes.js",


### PR DESCRIPTION
- Fixed a crash caused by not populating the `exemptNames` param.